### PR TITLE
feat(server): Add originalUrl property to all responses

### DIFF
--- a/build-plugin/tasks/server.js
+++ b/build-plugin/tasks/server.js
@@ -18,8 +18,9 @@ app.post('/uploads', upload.single(), function(req, res) {
     body: req.body,
     method: req.method,
     contentType: req.header('content-type'),
-    Authorization: req.header('Authorization')
-    });
+    Authorization: req.header('Authorization'),
+    originalUrl: req.originalUrl
+  });
 });
 
 app.all('*', function(req, res) {
@@ -29,7 +30,8 @@ app.all('*', function(req, res) {
     body: req.body,
     method: req.method,
     contentType: req.header('content-type'),
-    Authorization: req.header('Authorization')
+    Authorization: req.header('Authorization'),
+    originalUrl: req.originalUrl
   });
 });
 


### PR DESCRIPTION
Whenever a request is sent back, the `originalUrl` contains the unmodified url sent by the client.

This is needed for the tests contained in https://github.com/SpoonX/aurelia-api/pull/175
