### PR TITLE
Routing in individual gulpfiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,10 @@ The options for spoonx-tools can be set in `spoonx.js`. There are some other fil
 - contains a karma testing setup
 - sensible eslint rules
 - all settings combined in `spoonx.js`
+- testing express server routes are to be set in the plugin's `gulpfile.js`.
 
-## Doumentation
+## Documentation
 
-See [aurelia-plugin-skeleton](https://github.com/SpoonX/aurelia-plugin-skeleton) 
+Type `gulp help` for the available tasks.
+
+For a starter plugin project, see [aurelia-plugin-skeleton](https://github.com/SpoonX/aurelia-plugin-skeleton).

--- a/build-plugin/tasks/default.js
+++ b/build-plugin/tasks/default.js
@@ -1,0 +1,3 @@
+var gulp = require('gulp');
+
+gulp.task('default', ['help']);

--- a/build-plugin/tasks/server.js
+++ b/build-plugin/tasks/server.js
@@ -3,39 +3,9 @@ var bodyParser = require('body-parser');
 var cors       = require('cors');
 var server;
 
-var multer  = require('multer')
-var storage = multer.memoryStorage()
-var upload = multer({ storage: storage })
-
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: true }));
 app.use(cors());
-
-app.post('/uploads', upload.single(), function(req, res) {
-  res.send({
-    path: req.path,
-    query: req.query,
-    body: req.body,
-    method: req.method,
-    contentType: req.header('content-type'),
-    Authorization: req.header('Authorization'),
-    originalUrl: req.originalUrl
-  });
-});
-
-app.all('*', function(req, res) {
-  res.send({
-    path: req.path,
-    query: req.query,
-    body: req.body,
-    method: req.method,
-    contentType: req.header('content-type'),
-    Authorization: req.header('Authorization'),
-    originalUrl: req.originalUrl,
-    access_token: req.body.access_token,
-    refresh_token: req.body.refresh_token
-  });
-});
 
 module.exports = {
   app: app,

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "karma-jasmine": "^1.0.2",
     "karma-jspm": "^2.2.0",
     "merge2": "^1.0.2",
-    "multer": "^1.2.0",
     "object.assign": "^4.0.4",
     "require-dir": "^0.3.0",
     "run-sequence": "^1.2.2",


### PR DESCRIPTION
Moving routing add flexibility for testing and avoids unnecessary changes to spoonx-tools when different routes are needed
 